### PR TITLE
Set a default width if width < 360 (arbitrary number) for detecting long messages

### DIFF
--- a/public/s/styles/scss/client.scss
+++ b/public/s/styles/scss/client.scss
@@ -1043,7 +1043,7 @@ body {
 	&.chat-item-long {
 		@extend %ease;
 
-		max-height: 9em;
+		max-height: 12em;
 		cursor: pointer;
 
 		&:hover, &:focus {

--- a/ui/chat.js
+++ b/ui/chat.js
@@ -43,9 +43,13 @@ $(function () {
 
 		if (text.text) {
 			var $container = $(".chat-area"),
-				charsPerLine = $container.width() / (parseInt($container.css("font-size"), 10) * 0.6),
+				width = $container.width(),
 				lines = text.text.split("\n"),
-				lineCount = 0;
+				lineCount = 0,
+				charsPerLine;
+
+			width = (width > 360) ? width : 360;
+			charsPerLine = width / (parseInt($container.css("font-size"), 10) * 0.6);
 
 			lines.forEach(function(line) {
 				lineCount += Math.ceil(line.length/charsPerLine);


### PR DESCRIPTION
For some weird reason, chrome returns the width of $(".chat-area") as 10px whereas firefox returns it as null. Hence I cannot check if width is not defined or null. So I'm setting a width 360px if the width value returned is lower.
