### PR TITLE
Remove unnecessary files from appcache

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,7 +116,9 @@ gulp.task("manifest", function() {
 	return gulp.src([
 		"public/**/*",
 		"!public/{**/*.html,t/**}",
-		"!public/s/{*,js/*,img/*,img/covers/*,styles/scss/*}"
+		"!public/s/{*,img/*,img/covers/*,styles/scss/*}",
+		"!public/s/scripts/{*/*.map,js/*,lib/*}",
+		"!public/s/styles/{*/*.map,css/*,lace/*,scss/*}"
 	])
 	.pipe(manifest({
 		cache: [


### PR DESCRIPTION
File count is now 54 instead of 94.

Also, need to remove residual files from main server as lots of old unnecessary files are being included in the manifest.appcache file.
