### PR TITLE
Adding "//" part to server.host

### DIFF
--- a/client-config-defaults.js
+++ b/client-config-defaults.js
@@ -2,7 +2,7 @@ var merge = require("./merge-config.js");
 var defaults = {
 	server: {
 		protocol: "http:",
-		host: "local.scrollback.io"
+		host: "//local.scrollback.io"
 	},
     localStorage: {
         version: 1.00


### PR DESCRIPTION
Without it, socket/socket-client.js::connect fails. One note: script client-config-sample.js already holds the right value.