### PR TITLE
Fix JSCS config and added a gulp task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = tab
+indent_size = 4
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{css,less,scss}]
+indent_style = space
+indent_size = 4
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 .*
 !.brackets.json
+!.editorconfig
 !.gitignore
 !.git-hooks
 !.jscsrc

--- a/.jscsrc
+++ b/.jscsrc
@@ -13,18 +13,16 @@
     "requireMultipleVarDecl": true,
     "requireCommaBeforeLineBreak": true,
     "requireCamelCaseOrUpperCaseIdentifiers": true,
-    "requireDotNotation": true,
-    "maximumLineLength": {
-        "tabSize": 4,
-        "allowUrlComments": true,
-        "allowRegex": true
-    },
+    "requireDotNotation": "except_snake_case",
+    "requireSpacesInForStatement": true,
+    "requireSpaceBetweenArguments": true,
 
     "disallowMixedSpacesAndTabs": "smart",
     "disallowTrailingWhitespace": true,
     "disallowMultipleLineStrings": true,
     "disallowTrailingComma": true,
 
+    "requireSpaceBeforeBlockStatements": true,
     "requireSpacesInFunctionExpression": {
         "beforeOpeningCurlyBrace": true
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -249,7 +249,6 @@ gulp.task("styles", [ "lace", "fonts" ], function() {
 });
 
 // Generate appcache manifest file
-
 gulp.task("client-manifest", function() {
 	return genmanifest(prefix("public/s/", [
 		"scripts/lib/jquery.min.js",
@@ -281,10 +280,16 @@ gulp.task("clean", function() {
 	], dirs.lib, dirs.css, dirs.lace, dirs.fonts));
 });
 
+// Watch for changes
 gulp.task("watch", function() {
 	gulp.watch(files.js, [ "scripts", "manifest" ]);
 	gulp.watch(files.scss, [ "styles", "manifest" ]);
 });
 
+// Build all files
+gulp.task("build", [ "scripts", "styles", "manifest" ]);
+
 // Default Task
-gulp.task("default", [ "lint", "scripts", "styles", "manifest" ]);
+gulp.task("default", [ "clean", "lint" ], function() {
+	gulp.start("build");
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var gulp = require("gulp"),
 	gutil = require("gulp-util"),
 	sourcemaps = require("gulp-sourcemaps"),
 	jshint = require("gulp-jshint"),
+	jscs = require("gulp-jscs"),
 	gitmodified = require("gulp-gitmodified"),
 	symlink = require("gulp-sym"),
 	concat = require("gulp-concat"),
@@ -143,7 +144,7 @@ gulp.task("hooks", function() {
 gulp.task("postinstall", [ "hooks" ]);
 
 // Lint JavaScript files
-gulp.task("lint", function() {
+gulp.task("jshint", function() {
 	return gulp.src(files.js)
 	.pipe(plumber({ errorHandler: onerror }))
 	.pipe(gitmodified("modified"))
@@ -151,6 +152,15 @@ gulp.task("lint", function() {
 	.pipe(jshint.reporter("jshint-stylish"))
 	.pipe(jshint.reporter("fail"));
 });
+
+gulp.task("jscs", function() {
+	return gulp.src(files.js)
+	.pipe(plumber({ errorHandler: onerror }))
+	.pipe(gitmodified("modified"))
+	.pipe(jscs());
+});
+
+gulp.task("lint", [ "jshint" ]);
 
 // Install and copy third-party libraries
 gulp.task("bower", function() {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "gulp-combine-mq": "latest",
     "gulp-concat": "latest",
     "gulp-gitmodified": "latest",
+    "gulp-jscs": "latest",
     "gulp-jshint": "latest",
     "gulp-manifest": "git://github.com/scrollback/gulp-manifest.git#v0.0.7",
     "gulp-minify-css": "latest",


### PR DESCRIPTION
Due to invalid config, JSCS was crashing and was unusable (e.g. - No warnings were there in Sublime Text).

Also added a gulp task (not present in the default and lint tasks) so that someone could run jscs on modified files easily.

Added a .editorconfig file for consistent editor config (plugin install needed), e.g. - tabs indentation.